### PR TITLE
Fix for successive exports.some = some; statements and add support for module.exports = { a: b, c }

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,12 @@
 
 exports.onHandleCode = function onHandleCode(ev) {
   ev.data.code = ev.data.code
+    .replace(/module\s*\.\s*exports\s*=\s*{\s*([\s\S]*?)\s*}\s*;/gm,
+        function(str, exports) {
+          return 'export { ' +
+            exports.replace(/(\w+)\s*:\s*(\w+)\s*/g, '$2 as $1') +
+              ' };';
+        })
     .replace(/module\s*\.\s*exports\s*=\s?/g,
              'export default ')
     .replace(/exports\s*\.\s*([_\d\w]+)\s*=\s*(class|function\*?)\s+\1/g,

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ exports.onHandleCode = function onHandleCode(ev) {
              'export default ')
     .replace(/exports\s*\.\s*([_\d\w]+)\s*=\s*(class|function\*?)\s+\1/g,
              'export $2 $1')
-    .replace(/exports\s*\.\s*([_\d\w]+)\s*=\s*\1\s*;/,
+    .replace(/exports\s*\.\s*([_\d\w]+)\s*=\s*\1\s*;/g,
              'export { $1 };')
     .replace(/exports\s*\.\s*([_\d\w]+)\s*=/,
              'export let $1 =');

--- a/test.js
+++ b/test.js
@@ -15,15 +15,15 @@ test('export default', function(t) {
            'export default hello;');
 });
 
-test('export default', function(t) {
+test('export list', function(t) {
   t.plan(1);
   t.equals(f('module . exports = { hello, world };'),
       'export { hello, world };');
 });
 
-test('export default', function(t) {
+test('export named list', function(t) {
   t.plan(1);
-  t.equals(f('module . exports = { hi: hello, earth: world };'),
+  t.equals(f('module . exports = { hi: hello, earth :world };'),
       'export { hello as hi, world as earth };');
 });
 

--- a/test.js
+++ b/test.js
@@ -29,6 +29,12 @@ test('export { named };', function(t) {
            'export { some };');
 });
 
+test('export { named };', function(t) {
+  t.plan(1);
+  t.equals(f('exports . some = some; exports . someOther = someOther;'),
+      'export { some }; export { someOther };');
+});
+
 test('export let', function(t) {
   t.plan(1);
   t.equals(f('exports . hello = "world";'),

--- a/test.js
+++ b/test.js
@@ -15,6 +15,18 @@ test('export default', function(t) {
            'export default hello;');
 });
 
+test('export default', function(t) {
+  t.plan(1);
+  t.equals(f('module . exports = { hello, world };'),
+      'export { hello, world };');
+});
+
+test('export default', function(t) {
+  t.plan(1);
+  t.equals(f('module . exports = { hi: hello, earth: world };'),
+      'export { hello as hi, world as earth };');
+});
+
 test('export class|function', function(t) {
   t.plan(2);
   t.equals(f('exports . Hello = class Hello {};'),


### PR DESCRIPTION
Currently, this JavaScript code:
```javascript
exports.some = some;
exports.someOther = someOther;
```
is converted by esdoc-node to:
```javascript
export { some };
export let someOther = someOther;
```
instead of:
```javascript
export { some };
export { someOther };
```

This PR fixes this problem.