### PR TITLE
Add support for require statements

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # esdoc-node
 
-[![](https://travis-ci.org/ddude/esdoc-node.svg)](https://travis-ci.org/ddude/esdoc-node)
+[![](https://travis-ci.org/lcodes/esdoc-node.svg)](https://travis-ci.org/lcodes/esdoc-node)
 
 ## Usage
 
@@ -21,7 +21,7 @@ Add the following to your esdoc config file:
 ## What it does
 
 It converts the input of esdoc so that node.js' `exports` and
-`module.exports` becomes ES6's `export`.
+`module.exports` becomes ES6's `export`, and `require` becomes `import`.
 
 This table shows the translation rules:
 
@@ -32,3 +32,6 @@ This table shows the translation rules:
 |`exports.world = function world() { ... };`|`export function world() { ... };`|
 |`exports.value = value;`                   |`export { value };`               |
 |`exports.value = ...;`                     |`export let value = ...;`         |
+|`const value = require(...)`               |`import value from '...';`        |
+|`const { one, two } = require(...)`        |`import { one, two} from '...';`  |
+|`require(...)`                             |`import '...';`                   |

--- a/index.js
+++ b/index.js
@@ -15,5 +15,11 @@ exports.onHandleCode = function onHandleCode(ev) {
     .replace(/exports\s*\.\s*([_\d\w]+)\s*=\s*\1\s*;/g,
              'export { $1 };')
     .replace(/exports\s*\.\s*([_\d\w]+)\s*=/g,
-             'export let $1 =');
+             'export let $1 =')
+    .replace(/^(?:const|var|let)\s(\w+)\s*=\s*require\s*\(\s*(.*?)\s*\)/gm,
+             'import $1 from $2')
+    .replace(/^(?:const|var|let)\s*(\{(?:[\s\S]*?)\})\s*=\s*require\s*\(\s*(.*?)\s*\)/gm,
+             'import $1 from $2')
+    .replace(/^require\s*\(\s*(.*?)\s*\)/gm,
+             'import $1');
 };

--- a/test.js
+++ b/test.js
@@ -58,3 +58,39 @@ test('export let multiple', function(t) {
   t.equals(f('exports . some = "some"; exports . someOther = "someOther";'),
            'export let some = "some"; export let someOther = "someOther";');
 });
+
+test('variable = require', function(t) {
+  t.plan(3);
+  t.equals(f('const esdoc = require("esdoc");'),
+           'import esdoc from "esdoc";');
+  t.equals(f('let esdoc = require("esdoc");'),
+           'import esdoc from "esdoc";');
+  t.equals(f('var esdoc = require("esdoc");'),
+           'import esdoc from "esdoc";');
+});
+
+test('{ named } = require', function(t) {
+  t.plan(3);
+  t.equals(f('const { esdoc } = require("esdoc");'),
+           'import { esdoc } from "esdoc";');
+  t.equals(f('let { esdoc } = require("esdoc");'),
+           'import { esdoc } from "esdoc";');
+  t.equals(f('var { esdoc } = require("esdoc");'),
+           'import { esdoc } from "esdoc";');
+});
+
+test('{ named } = require multiple', function(t) {
+  t.plan(3);
+  t.equals(f('const { esdoc, another, named, module } = require("esdoc");'),
+           'import { esdoc, another, named, module } from "esdoc";');
+  t.equals(f('let { esdoc, another, named, module } = require("esdoc");'),
+           'import { esdoc, another, named, module } from "esdoc";');
+  t.equals(f('var { esdoc, another, named, module } = require("esdoc");'),
+           'import { esdoc, another, named, module } from "esdoc";');
+});
+
+test('require', function(t) {
+  t.plan(1);
+  t.equals(f('require("esdoc");'),
+           'import "esdoc";');
+});


### PR DESCRIPTION
### What does this PR do?

First of all... thank you!!! ESDoc is great, but the fact that it doesn't support `module.exports` nor `require` is crazy. :P.

If you are using `module.exports`, chances are that you are also probably using `require` instead of `import`, and ESDoc marks all those `(const|let|var) \w+ = require(...)` as undocumented if you don't describe them with a type.

Well, this PR aims to replace those `require`s so ESDoc will think you are using both `import` and `export` and the code is full ES6.

- I updated the code with new regular expressions.
- I added a few test cases for the new expressions.
- I updated the `README.me` with a few examples.
- I fixed the Travis badge URL on the `README` because of reasons :P.

PS: ESLint was throwing errors EVERYWHERE, but I didn't want to make those changes because even if you have the `.eslintrc`, you don't have ESLint as a dependency, so I assumed is not "fully implemented yet".

### How should it be tested manually?

`npm test`