### PR TITLE
Failed when use in require('...') deep destructuring

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,4 +34,7 @@ This table shows the translation rules:
 |`exports.value = ...;`                     |`export let value = ...;`         |
 |`const value = require(...)`               |`import value from '...';`        |
 |`const { one, two } = require(...)`        |`import { one, two} from '...';`  |
+|`const { one: two } = require(...)`        |`import { one as two} from '...';`|
+|`const { one: { two } } = require(...)`    |`import * as random from '...';`  |
+|                                           |`const { one: { two } } = random;`|
 |`require(...)`                             |`import '...';`                   |

--- a/index.js
+++ b/index.js
@@ -1,14 +1,12 @@
-'use strict';
-
 exports.onHandleCode = function onHandleCode(ev) {
-  var varCount = -1;
+  let varCount = -1;
 
   ev.data.code = ev.data.code
     .replace(/module\s*\.\s*exports\s*=\s*{\s*([\s\S]*?)\s*}\s*;/gm,
-      function(str, exports) {
+      (str, exports) => {
         return 'export { ' +
-            exports.replace(/(\w+)\s*:\s*(\w+)\s*/g, '$2 as $1') +
-              ' };';
+          exports.replace(/(\w+)\s*:\s*(\w+)\s*/g, '$2 as $1') +
+          ' };';
       })
     .replace(/module\s*\.\s*exports\s*=\s?/g,
       'export default ')
@@ -19,8 +17,8 @@ exports.onHandleCode = function onHandleCode(ev) {
     .replace(/exports\s*\.\s*([_\d\w]+)\s*=/g,
       'export let $1 =')
     .replace(/^(?:const|var|let)\s(\w+)\s*=\s*require\s*\(\s*(.*?)\s*\)(.*?)$/gm,
-      function(str, a, b, c) {
-        var next = c.substring(0, 1);
+      (str, a, b, c) => {
+        const next = c.substring(0, 1);
         if (next === '.' || next === '(') {
           return 'import ' + a + ' from ' + b + '; ' + a + c;
         }
@@ -36,8 +34,8 @@ exports.onHandleCode = function onHandleCode(ev) {
         return `import * as ${hash} from ${b}; \nconst ${a} = ${hash}`;
       })
     .replace(/^require\s*\(\s*(.*?)\s*\)(.*?)$/gm,
-      function(str, a, b) {
-        var next = b.substring(0, 1);
+      (str, a, b) => {
+        const next = b.substring(0, 1);
         if (next === '.' || next === '(') {
           varCount++;
           return 'import ESDOC_NODE_VAR_' + varCount + ' from ' + a + '; ESDOC_NODE_VAR_' + varCount + b;

--- a/index.js
+++ b/index.js
@@ -28,16 +28,12 @@ exports.onHandleCode = function onHandleCode(ev) {
       })
     .replace(/^(?:const|var|let)\s*(\{(?:[\s\S]*?)\})\s*=\s*require\s*\(\s*(.*?)\s*\)/gm,
       (str, a, b) => {
-      // test case -  const {name:other/name} = require('name');
-        if (/{\s*(\w+):\s*(\w+)\s*}/gm.test(a)) {
-          const [full, key, value] = a.match(/{\s*(\w+):\s*(\w+)\s*}/s);
-          return `import ${key} as ${value} from ${b}`;
+        if (/{(\s*\w+\s*,){0,}\s*(\w+)\s*:\s*(\w+)\s*(,\s*(\w+)\s*:\s*(\w+)\s*){0,}(,\s*\w+\s*){0,}}/gm.test(a)) {
+          const [full] = a.match(/{(\s*\w+\s*,){0,}\s*(\w+)\s*:\s*(\w+)\s*(,\s*(\w+)\s*:\s*(\w+)\s*){0,}(,\s*\w+\s*){0,}}/s);
+          return `import ${full.replace(/:/gm, ' as ')} from ${b}`;
         }
-        // test case -  const {name} = require('name');
-        if (/{\s*\w+\s*}/s.test(a)) {
-          const [full] = a.match(/{\s*\w+\s*}/s);
-          return `import ${full} from ${b}`;
-        }
+        const hash = (Date.now().toString(36) + Math.random().toString(36).substr(2, 5)).toUpperCase();
+        return `import * as ${hash} from ${b}; \nconst ${a} = ${hash}`;
       })
     .replace(/^require\s*\(\s*(.*?)\s*\)(.*?)$/gm,
       function(str, a, b) {

--- a/index.js
+++ b/index.js
@@ -27,7 +27,18 @@ exports.onHandleCode = function onHandleCode(ev) {
         return 'import ' + a + ' from ' + b + c;
       })
     .replace(/^(?:const|var|let)\s*(\{(?:[\s\S]*?)\})\s*=\s*require\s*\(\s*(.*?)\s*\)/gm,
-      'import $1 from $2')
+      (str, a, b) => {
+      // test case -  const {name:other/name} = require('name');
+        if (/{\s*(\w+):\s*(\w+)\s*}/gm.test(a)) {
+          const [full, key, value] = a.match(/{\s*(\w+):\s*(\w+)\s*}/s);
+          return `import ${key} as ${value} from ${b}`;
+        }
+        // test case -  const {name} = require('name');
+        if (/{\s*\w+\s*}/s.test(a)) {
+          const [full] = a.match(/{\s*\w+\s*}/s);
+          return `import ${full} from ${b}`;
+        }
+      })
     .replace(/^require\s*\(\s*(.*?)\s*\)(.*?)$/gm,
       function(str, a, b) {
         var next = b.substring(0, 1);

--- a/test.js
+++ b/test.js
@@ -79,22 +79,12 @@ test('variable = require w/ suffix', function(t) {
 
 test('{ named } = require', function(t) {
   t.plan(3);
-  t.equals(f('const { esdoc } = require("esdoc");'),
-    'import { esdoc } from "esdoc";');
-  t.equals(f('let { esdoc } = require("esdoc");'),
-    'import { esdoc } from "esdoc";');
-  t.equals(f('var { esdoc } = require("esdoc");'),
-    'import { esdoc } from "esdoc";');
-});
-
-test('{ named } = require multiple', function(t) {
-  t.plan(3);
-  t.equals(f('const { esdoc, another, named, module } = require("esdoc");'),
-    'import { esdoc, another, named, module } from "esdoc";');
-  t.equals(f('let { esdoc, another, named, module } = require("esdoc");'),
-    'import { esdoc, another, named, module } from "esdoc";');
-  t.equals(f('var { esdoc, another, named, module } = require("esdoc");'),
-    'import { esdoc, another, named, module } from "esdoc";');
+  t.equals(f('const { esdoc: doc } = require("esdoc");'),
+    'import { esdoc as  doc } from "esdoc";');
+  t.equals(f('let { esdoc: doc } = require("esdoc");'),
+    'import { esdoc as  doc } from "esdoc";');
+  t.equals(f('var { esdoc: doc } = require("esdoc");'),
+    'import { esdoc as  doc } from "esdoc";');
 });
 
 test('require', function(t) {


### PR DESCRIPTION
ESDoc failed when generate documentation because esdoc-node plugin doesn't work with such cases as:
`const { one: { two } } = required('...');`
and
`const { one: two } = required('...');`

in current version it will be converted to:
`import * randomString from '...'`
`const { one: { two } } = randomString` 
and
`import { one as two } from ('...');`